### PR TITLE
Update User Agent string to fix YouTube old browser error

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -121,7 +121,7 @@ class Util {
                 headers: Object.assign(
                     {},
                     {
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0"
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; rv:140.0) Gecko/20100101 Firefox/140.0"
                     },
                     requestOptions?.headers || {}
                 )


### PR DESCRIPTION
When using `YouTube.getVideo` API method, you always get this error:
```
F:\source\test\node_modules\youtube-sr\dist\mod.js:891
      throw new Error("Could not parse video metadata!");
            ^

Error: Could not parse video metadata!
    at Util.getVideo (F:\source\test\node_modules\youtube-sr\dist\mod.js:891:13)
    at YouTube.<anonymous> (F:\source\test\node_modules\youtube-sr\dist\mod.js:1281:27)
    at Generator.next (<anonymous>)
    at fulfilled (F:\source\test\node_modules\youtube-sr\dist\mod.js:44:24)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

After some debugging I found that the HTML page returned from YouTube is a redirect to outdated browser page.

Updating User Agent header string to the latest Firefox version fixes this issue.