### PR TITLE
Update User Agent so that mix queries still work

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -121,7 +121,7 @@ class Util {
                 headers: Object.assign(
                     {},
                     {
-                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; rv:78.0) Gecko/20100101 Firefox/78.0"
+                        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:139.0) Gecko/20100101 Firefox/139.0"
                     },
                     requestOptions?.headers || {}
                 )


### PR DESCRIPTION
Else you get on getHTML for mix Urls "Browser is not supported"