### PR TITLE
Fix youtubei endpoint and html parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "prepublishOnly": "bun run build",
     "build:node": "tsup",
     "build:deno": "node scripts/deno.js",
-    "format": "prettier --write \"**/*.{js,ts}\""
+    "format": "prettier --write \"**/*.{js,ts}\"",
+    "prepare": "tsup"
   },
   "repository": {
     "type": "git",

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -659,8 +659,7 @@ class Util {
     }
 
     static async makeRequest(url = "", data: any = { data: {}, requestOptions: {} }) {
-        const key = await Util.innertubeKey();
-        const res = await Util.getHTML(`https://youtube.com/youtubei/v1${url}?key=${key}`, {
+        const res = await Util.getHTML(`https://www.youtube.com/youtubei/v1${url}`, {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -221,27 +221,33 @@ class Util {
         if (!data || !data.videoRenderer) return;
 
         const badge = data.videoRenderer.ownerBadges && data.videoRenderer.ownerBadges[0];
+        const vidRender = data.videoRenderer;
+        const vidThumbnail = vidRender.thumbnail.thumbnails;
+        const navigationEndpoint = vidRender.ownerText.runs[0].navigationEndpoint;
+        const browseEndpoint = navigationEndpoint.browseEndpoint
+            ?? navigationEndpoint.showDialogCommand?.panelLoadingStrategy?.inlineContent?.dialogViewModel?.customContent?.listViewModel?.listItems?.[0]?.listItemViewModel?.title?.commandRuns?.[0]?.onTap?.innertubeCommand?.browseEndpoint
+            ?? {}
         let res = new Video({
             id: data.videoRenderer.videoId,
             url: `https://www.youtube.com/watch?v=${data.videoRenderer.videoId}`,
-            title: data.videoRenderer.title.runs[0].text,
-            description: data.videoRenderer.descriptionSnippet && data.videoRenderer.descriptionSnippet.runs[0] ? data.videoRenderer.descriptionSnippet.runs[0].text : "",
-            duration: data.videoRenderer.lengthText ? Util.parseDuration(data.videoRenderer.lengthText.simpleText) : 0,
-            duration_raw: data.videoRenderer.lengthText ? data.videoRenderer.lengthText.simpleText : null,
+            title: vidRender.title.runs[0].text,
+            description: vidRender.descriptionSnippet && vidRender.descriptionSnippet.runs[0] ? vidRender.descriptionSnippet.runs[0].text : "",
+            duration: vidRender.lengthText ? Util.parseDuration(vidRender.lengthText.simpleText) : 0,
+            duration_raw: vidRender.lengthText ? vidRender.lengthText.simpleText : null,
             thumbnail: {
-                id: data.videoRenderer.videoId,
-                url: data.videoRenderer.thumbnail.thumbnails[data.videoRenderer.thumbnail.thumbnails.length - 1].url,
-                height: data.videoRenderer.thumbnail.thumbnails[data.videoRenderer.thumbnail.thumbnails.length - 1].height,
-                width: data.videoRenderer.thumbnail.thumbnails[data.videoRenderer.thumbnail.thumbnails.length - 1].width
+                id: vidRender.videoId,
+                url: vidThumbnail[vidThumbnail.length - 1].url,
+                height: vidThumbnail[vidThumbnail.length - 1].height,
+                width: vidThumbnail[vidThumbnail.length - 1].width
             },
             channel: {
-                id: data.videoRenderer.ownerText.runs[0].navigationEndpoint.browseEndpoint.browseId || null,
-                name: data.videoRenderer.ownerText.runs[0].text || null,
-                url: `https://www.youtube.com${data.videoRenderer.ownerText.runs[0].navigationEndpoint.browseEndpoint.canonicalBaseUrl || data.videoRenderer.ownerText.runs[0].navigationEndpoint.commandMetadata.webCommandMetadata.url}`,
+                id: browseEndpoint.browseId,
+                name: vidRender.ownerText.runs[0].text || null,
+                url: `https://www.youtube.com${browseEndpoint.canonicalBaseUrl || navigationEndpoint.commandMetadata.webCommandMetadata.url}`,
                 icon: {
-                    url: data.videoRenderer.channelThumbnail?.thumbnails?.[0]?.url || data.videoRenderer.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.url,
-                    width: data.videoRenderer.channelThumbnail?.thumbnails?.[0]?.width || data.videoRenderer.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.width,
-                    height: data.videoRenderer.channelThumbnail?.thumbnails?.[0]?.height || data.videoRenderer.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.height
+                    url: vidRender.channelThumbnail?.thumbnails?.[0]?.url || vidRender.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.url,
+                    width: vidRender.channelThumbnail?.thumbnails?.[0]?.width || vidRender.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.width,
+                    height: vidRender.channelThumbnail?.thumbnails?.[0]?.height || vidRender.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.height
                 },
                 verified: Boolean(badge?.metadataBadgeRenderer?.style?.toLowerCase().includes("verified"))
             },

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -180,28 +180,12 @@ class Util {
 
         // try to parse html
         try {
-            let data = html.split("ytInitialData = JSON.parse('")[1].split("');</script>")[0];
-            html = data.replace(/\\x([0-9A-F]{2})/gi, (...items) => {
-                return String.fromCharCode(parseInt(items[1], 16));
-            });
-        } catch {
-            /* do nothing */
-        }
-
-        try {
-            details = JSON.parse(html.split('{"itemSectionRenderer":{"contents":')[html.split('{"itemSectionRenderer":{"contents":').length - 1].split(',"continuations":[{')[0]);
+            const pattern = new RegExp("ytInitialData\\s*=\\s*(.*?)(?:;?)<\\/script>", "s");
+            const match = html.match(pattern);
+            details = JSON.parse(match[1]).contents.twoColumnSearchResultsRenderer.primaryContents.sectionListRenderer.contents[0].itemSectionRenderer.contents;
             fetched = true;
         } catch {
             /* do nothing */
-        }
-
-        if (!fetched) {
-            try {
-                details = JSON.parse(html.split('{"itemSectionRenderer":')[html.split('{"itemSectionRenderer":').length - 1].split('},{"continuationItemRenderer":{')[0]).contents;
-                fetched = true;
-            } catch {
-                /* do nothing */
-            }
         }
 
         if (!fetched) return [];

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -225,7 +225,8 @@ class Util {
         const vidThumbnail = vidRender.thumbnail.thumbnails;
         const navigationEndpoint = vidRender.ownerText.runs[0].navigationEndpoint;
         const browseEndpoint = navigationEndpoint.browseEndpoint
-            ?? navigationEndpoint.showDialogCommand?.panelLoadingStrategy?.inlineContent?.dialogViewModel?.customContent?.listViewModel?.listItems?.[0]?.listItemViewModel?.title?.commandRuns?.[0]?.onTap?.innertubeCommand?.browseEndpoint
+            ?? vidRender?.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.navigationEndpoint?.browseEndpoint
+            ?? navigationEndpoint?.showDialogCommand?.panelLoadingStrategy?.inlineContent?.dialogViewModel?.customContent?.listViewModel?.listItems?.[0]?.listItemViewModel?.title?.commandRuns?.[0]?.onTap?.innertubeCommand?.browseEndpoint
             ?? {}
         let res = new Video({
             id: data.videoRenderer.videoId,
@@ -243,7 +244,7 @@ class Util {
             channel: {
                 id: browseEndpoint.browseId,
                 name: vidRender.ownerText.runs[0].text || null,
-                url: `https://www.youtube.com${browseEndpoint.canonicalBaseUrl || navigationEndpoint.commandMetadata.webCommandMetadata.url}`,
+                url: `https://www.youtube.com${browseEndpoint?.canonicalBaseUrl || navigationEndpoint?.commandMetadata?.webCommandMetadata?.url}`,
                 icon: {
                     url: vidRender.channelThumbnail?.thumbnails?.[0]?.url || vidRender.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.url,
                     width: vidRender.channelThumbnail?.thumbnails?.[0]?.width || vidRender.channelThumbnailSupportedRenderers?.channelThumbnailWithLinkRenderer?.thumbnail?.thumbnails?.[0]?.width,


### PR DESCRIPTION
The youtubei search API gives a bad request if you’re not using the www subdomain. Also, with the new YouTube update, a single video can be linked to multiple channels, which breaks the parseVideo function.

<img width="1234" height="290" alt="image" src="https://github.com/user-attachments/assets/af99e6ce-6066-4d22-9985-cce3bdeaf38a" />
